### PR TITLE
fix #4

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -41,12 +41,12 @@ end
 
 def add_tailwind
   run "yarn add tailwindcss"
-  run "mkdir app/javascript/stylesheets"
+  run "mkdir -p app/javascript/stylesheets"
   append_to_file("app/javascript/packs/application.js", 'import "stylesheets/application"')
   inject_into_file("./postcss.config.js",
   "var tailwindcss = require('tailwindcss');\n",  before: "module.exports")
   inject_into_file("./postcss.config.js", "\n    tailwindcss('./app/javascript/stylesheets/tailwind.config.js'),", after: "plugins: [")
-  run "mkdir app/javascript/stylesheets/components"
+  run "mkdir -p app/javascript/stylesheets/components"
 end
 
 # Remove Application CSS


### PR DESCRIPTION
added -p option to avoid "cannot create directory file exists" when creating `app/javascript/stylesheets` and `app/javascript/stylesheets/components` on `add_tailwind`

Issue #4