### PR TITLE
Fix partial name in passwords edit view

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -31,4 +31,4 @@
 
 <% end %>
 
-<%= render "devise/share/form_wrap" %>
+<%= render "devise/shared/form_wrap" %>


### PR DESCRIPTION
The `form_wrap` partial wasn't referenced properly in `app/views/devise/passwords/edit.html.erb` — `shared` was missing a `d`.